### PR TITLE
Force batch nested processing bug fixed

### DIFF
--- a/src/impls/nodes/utility/forceBatch.ts
+++ b/src/impls/nodes/utility/forceBatch.ts
@@ -31,7 +31,7 @@ export class ForceBatchNode implements NestedCallNode {
         endExclusive = indexOfCompletedEvent
 
         innerCalls.forEach((innerCall) => {
-            let [itemEvent, itemEventIdx] = context.eventQueue.peekItemFromEnd(CompletionEvents, endExclusive)
+            let [itemEvent, itemEventIdx] = context.eventQueue.peekItemFromEnd(ItemEvents, endExclusive)
 
             if (ItemCompleted.is(itemEvent)) {
                 // only completed items emit nested events


### PR DESCRIPTION
Typo fixed --> in innerCalls in endExclusiveToSkipInternalEvents we need to filter by ItemEvents, not by CompletionEvents. (inner events are processed with ItemEvents, current call find bounds with CompletionEvents)