### PR TITLE
add NewMultisig in CompletionEvents for asMulti

### DIFF
--- a/src/impls/nodes/multisig/asMulti.ts
+++ b/src/impls/nodes/multisig/asMulti.ts
@@ -4,10 +4,10 @@ import {AnyTuple} from "@polkadot/types-codec/types";
 import {IVec} from "@polkadot/types-codec/types/interfaces";
 import {AccountId} from "@polkadot/types/interfaces/runtime/types";
 import {INumber} from "@polkadot/types-codec/types/interfaces";
-import {generateMultisigAddress, MultisigApproval, MultisigExecuted} from "./common";
+import {generateMultisigAddress, MultisigApproval, MultisigExecuted, NewMultisig} from "./common";
 
 
-const CompletionEvents = [MultisigExecuted, MultisigApproval]
+const CompletionEvents = [MultisigExecuted, MultisigApproval, NewMultisig]
 
 export class AsMultiNode implements NestedCallNode {
 

--- a/src/impls/nodes/multisig/common.ts
+++ b/src/impls/nodes/multisig/common.ts
@@ -5,6 +5,7 @@ import {encodeMultiAddress, sortAddresses} from "@polkadot/util-crypto";
 
 export const MultisigExecuted = api.events.multisig.MultisigExecuted
 export const MultisigApproval = api.events.multisig.MultisigApproval
+export const NewMultisig = api.events.multisig.NewMultisig
 
 export function generateMultisigAddress(
     origin: string,


### PR DESCRIPTION
The problem was that there is three positive results of as_multi calls:

MultisigExecuted -- batch applied
MultisigApproval -- approval from one of signers received
NewMultisig -- Multisig account just created

Previously, we only handled the first two types of outcomes.

This mr adds a third.

Logs after changes are attached (verification was done by making changes to the library directly in the governance project)

[error.log](https://github.com/novasamatech/subquery-call-visitor/files/11906523/error.log)

[fixed.log](https://github.com/novasamatech/subquery-call-visitor/files/11906525/fixed.log)
