### PR TITLE
Fix processing order for force batch and batch all

### DIFF
--- a/src/impls/nodes/utility/batchAll.ts
+++ b/src/impls/nodes/utility/batchAll.ts
@@ -26,10 +26,11 @@ export class BatchAllNode implements NestedCallNode {
         endExclusive = indexOfCompletedEvent
 
         // bathAll completed means all calls have completed
-        innerCalls.forEach((innerCall) => {
+        for (let i = innerCalls.length - 1; i >= 0; i--) {
+            let innerCall = innerCalls[i]
             let itemIdx = context.eventQueue.indexOfLast(ItemEvents, endExclusive)
             endExclusive = context.endExclusiveToSkipInternalEvents(innerCall, itemIdx)
-        })
+        }
 
         return endExclusive
     }

--- a/src/impls/nodes/utility/forceBatch.ts
+++ b/src/impls/nodes/utility/forceBatch.ts
@@ -30,7 +30,8 @@ export class ForceBatchNode implements NestedCallNode {
         }
         endExclusive = indexOfCompletedEvent
 
-        innerCalls.forEach((innerCall) => {
+        for (let i = innerCalls.length - 1; i >= 0; i--) {
+            let innerCall = innerCalls[i]
             let [itemEvent, itemEventIdx] = context.eventQueue.peekItemFromEnd(ItemEvents, endExclusive)
 
             if (ItemCompleted.is(itemEvent)) {
@@ -39,7 +40,7 @@ export class ForceBatchNode implements NestedCallNode {
             } else {
                 endExclusive = itemEventIdx
             }
-        })
+        }
 
         return endExclusive
     }


### PR DESCRIPTION
As we extracting events from the end to handle parent call then we must visit nested calls in reverse order too