### PR TITLE
fix: MultisigExecuted is not defined in api

### DIFF
--- a/src/impls/nodes/multisig/common.ts
+++ b/src/impls/nodes/multisig/common.ts
@@ -2,9 +2,9 @@ import {IVec} from "@polkadot/types-codec/types/interfaces";
 import {AccountId} from "@polkadot/types/interfaces/runtime/types";
 import {encodeMultiAddress, ethereumEncode, isEthereumAddress, createKeyMulti} from "@polkadot/util-crypto";
 
-export const MultisigExecuted = api.events.multisig.MultisigExecuted
-export const MultisigApproval = api.events.multisig.MultisigApproval
-export const NewMultisig = api.events.multisig.NewMultisig
+export const MultisigExecuted = api.events?.multisig?.MultisigExecuted
+export const MultisigApproval = api.events?.multisig?.MultisigApproval
+export const NewMultisig = api.events?.multisig?.NewMultisig
 
 export function generateMultisigAddress(
     origin: string,


### PR DESCRIPTION
Faced on moonbeam:
```bash
2025-07-01T09:07:22.442Z <WorkerBlockDispatcherService> INFO Enqueueing blocks 4947...4956, total 10 blocks
2025-07-01 09:07:22        API/INIT: MetadataApi not available, rpc::state::get_metadata will be used.
2025-07-01T09:07:23.453Z <WorkerBlockDispatcherService> INFO {"threadId":1,"fetchedBlocks":0,"toFetchBlocks":18,"isIndexing":false}
2025-07-01T09:07:23.971Z <WorkerService-#1> ERROR Failed to index block 4939: TypeError: Cannot read properties of undefined (reading 'MultisigExecuted')
    at 9142 (webpack://subquery-proxy/node_modules/subquery-call-visitor/dist/impls/nodes/multisig/common.js:5:47)
    at i (webpack://subquery-proxy/webpack/bootstrap:19:31)
    at 3002 (webpack://subquery-proxy/node_modules/subquery-call-visitor/dist/impls/nodes/multisig/asMulti.js:4:17)
    at i (webpack://subquery-proxy/webpack/bootstrap:19:31)
    at 8954 (webpack://subquery-proxy/node_modules/subquery-call-visitor/dist/impls/index.js:5:16)
    at i (webpack://subquery-proxy/webpack/bootstrap:19:31)
    at 5902 (webpack://subquery-proxy/node_modules/subquery-call-visitor/dist/index.js:6:21)
    at i (webpack://subquery-proxy/webpack/bootstrap:19:31)
    at 1024 (webpack://subquery-proxy/src/mappings/handlers/multisigCallHandler.ts:11:32)
    at i (webpack://subquery-proxy/webpack/bootstrap:19:31) TypeError: Cannot read properties of undefined (reading 'MultisigExecuted')
2025-07-01T09:07:23.972Z <worker: 1> ERROR Worker error
2025-07-01T09:07:23.994Z <worker: 1> ERROR Worker exited with code 1
```

looks like on that block, moonbeam has no multisig pallet
https://moonbeam.subscan.io/block/4939