### PR TITLE
feat: implemented traverse stopping

### DIFF
--- a/src/impls/call-visitor.ts
+++ b/src/impls/call-visitor.ts
@@ -1,4 +1,4 @@
-import { CallHandler, CallVisitor, CallVisitorBuilder, VisitedCall } from '../interfaces';
+import { CallHandler, CallVisitor, CallVisitorBuilder, VisitedCall, VisitorContext } from '../interfaces';
 
 export function CreateCallVisitorBuilder(): CallVisitorBuilder {
   return new CallVisitorBuilderImpl();
@@ -12,8 +12,14 @@ class CallVisitorBuilderImpl implements CallVisitorBuilder {
     return new CallVisitorImpl(this.handlers, this._ignoreFailedCalls);
   }
 
-  on(module: string, call: string, handler: CallHandler): CallVisitorBuilder {
-    this.handlers[createHandlerKey(module, call)] = handler;
+  on(module: string, call: string | string[], handler: CallHandler): CallVisitorBuilder {
+    if (Array.isArray(call)) {
+      for (const c of call) {
+        this.handlers[createHandlerKey(module, c)] = handler;
+      }
+    } else {
+      this.handlers[createHandlerKey(module, call)] = handler;
+    }
 
     return this;
   }
@@ -34,14 +40,14 @@ class CallVisitorImpl implements CallVisitor {
     this.ignoreFailedCalls = ignoreFailedCalls;
   }
 
-  async visit(call: VisitedCall): Promise<void> {
+  async visit(call: VisitedCall, context: VisitorContext): Promise<void> {
     if (!call.success && this.ignoreFailedCalls) return;
 
     const handlerKey = createHandlerKey(call.call.section, call.call.method);
     const handler = this.handlers[handlerKey];
 
     if (handler != undefined) {
-      await handler(call);
+      await handler(call, context);
     }
   }
 }

--- a/src/impls/index.ts
+++ b/src/impls/index.ts
@@ -6,5 +6,5 @@ export { BatchAllNode } from './nodes/utility/batchAll';
 export { ForceBatchNode } from './nodes/utility/forceBatch';
 export { AsDerivativeNode } from './nodes/utility/asDerivative';
 
-export * from './call-visitor';
-export * from './call-walk';
+export { CreateCallVisitorBuilder } from './call-visitor';
+export { CreateCallWalk, DefaultKnownNodes } from './call-walk';

--- a/src/impls/nodes/multisig/asMulti.ts
+++ b/src/impls/nodes/multisig/asMulti.ts
@@ -1,4 +1,4 @@
-import { AnyEvent, EventCountingContext, NestedCallNode, VisitedCall, VisitingContext } from '../../../interfaces';
+import { AnyEvent, EventCountingContext, NestedCallNode, VisitedCall, NodeContext } from '../../../interfaces';
 import { CallBase } from '@polkadot/types/types/calls';
 import { AnyTuple } from '@polkadot/types-codec/types';
 import { IVec } from '@polkadot/types-codec/types/interfaces';
@@ -32,7 +32,7 @@ export class AsMultiNode implements NestedCallNode {
     return endExclusive;
   }
 
-  async visit(call: CallBase<AnyTuple>, context: VisitingContext): Promise<void> {
+  async visit(call: CallBase<AnyTuple>, context: NodeContext): Promise<void> {
     if (!context.callSucceeded) {
       await this.visitFailedMultisigCall(call, context);
       context.logger.info('asMulti - reverted by outer parent');
@@ -55,7 +55,7 @@ export class AsMultiNode implements NestedCallNode {
     }
   }
 
-  async visitFailedMultisigCall(call: CallBase<AnyTuple>, context: VisitingContext): Promise<void> {
+  async visitFailedMultisigCall(call: CallBase<AnyTuple>, context: NodeContext): Promise<void> {
     const visitedCall: VisitedCall = {
       success: false,
       origin: this.extractMultisigOrigin(call, context.origin),
@@ -67,7 +67,7 @@ export class AsMultiNode implements NestedCallNode {
     await context.nestedVisit(visitedCall);
   }
 
-  async visitSucceededMultisigCall(call: CallBase<AnyTuple>, context: VisitingContext): Promise<void> {
+  async visitSucceededMultisigCall(call: CallBase<AnyTuple>, context: NodeContext): Promise<void> {
     const visitedCall: VisitedCall = {
       success: true,
       origin: this.extractMultisigOrigin(call, context.origin),

--- a/src/impls/nodes/multisig/asMultiThreshold1.ts
+++ b/src/impls/nodes/multisig/asMultiThreshold1.ts
@@ -1,4 +1,4 @@
-import { EventCountingContext, NestedCallNode, VisitedCall, VisitingContext } from '../../../interfaces';
+import { EventCountingContext, NestedCallNode, VisitedCall, NodeContext } from '../../../interfaces';
 import { CallBase } from '@polkadot/types/types/calls';
 import { AnyTuple } from '@polkadot/types-codec/types';
 import { IVec } from '@polkadot/types-codec/types/interfaces';
@@ -20,7 +20,7 @@ export class AsMultiThreshold1Node implements NestedCallNode {
     return endExclusive;
   }
 
-  async visit(call: CallBase<AnyTuple>, context: VisitingContext): Promise<void> {
+  async visit(call: CallBase<AnyTuple>, context: NodeContext): Promise<void> {
     if (!context.callSucceeded) {
       await this.visitFailedMultisigCall(call, context);
       context.logger.info('Multisig - failed or reverted by outer parent');
@@ -32,7 +32,7 @@ export class AsMultiThreshold1Node implements NestedCallNode {
     await this.visitSucceededMultisigCall(call, context);
   }
 
-  private async visitFailedMultisigCall(call: CallBase<AnyTuple>, context: VisitingContext): Promise<void> {
+  private async visitFailedMultisigCall(call: CallBase<AnyTuple>, context: NodeContext): Promise<void> {
     const visitedCall: VisitedCall = {
       success: false,
       origin: this.extractMultisigOrigin(call, context.origin),
@@ -44,7 +44,7 @@ export class AsMultiThreshold1Node implements NestedCallNode {
     await context.nestedVisit(visitedCall);
   }
 
-  private async visitSucceededMultisigCall(call: CallBase<AnyTuple>, context: VisitingContext): Promise<void> {
+  private async visitSucceededMultisigCall(call: CallBase<AnyTuple>, context: NodeContext): Promise<void> {
     const visitedCall: VisitedCall = {
       success: true,
       origin: this.extractMultisigOrigin(call, context.origin),

--- a/src/impls/nodes/proxy/proxy.ts
+++ b/src/impls/nodes/proxy/proxy.ts
@@ -1,4 +1,4 @@
-import { AnyEvent, EventCountingContext, NestedCallNode, VisitedCall, VisitingContext } from '../../../interfaces';
+import { AnyEvent, EventCountingContext, NestedCallNode, VisitedCall, NodeContext } from '../../../interfaces';
 import { CallBase } from '@polkadot/types/types/calls';
 import { AnyTuple } from '@polkadot/types-codec/types';
 import { Codec } from '@polkadot/types/types';
@@ -33,7 +33,7 @@ export class ProxyNode implements NestedCallNode {
     return endExclusive;
   }
 
-  async visit(call: CallBase<AnyTuple>, context: VisitingContext): Promise<void> {
+  async visit(call: CallBase<AnyTuple>, context: NodeContext): Promise<void> {
     if (!context.callSucceeded) {
       await this.visitFailedProxyCall(call, context);
       context.logger.info('proxy - reverted by outer parent');
@@ -56,21 +56,21 @@ export class ProxyNode implements NestedCallNode {
     }
   }
 
-  async visitFailedProxyCall(call: CallBase<AnyTuple>, context: VisitingContext): Promise<void> {
+  async visitFailedProxyCall(call: CallBase<AnyTuple>, context: NodeContext): Promise<void> {
     const success = false;
     const events: AnyEvent[] = [];
 
     await this.visitProxyCall(call, context, success, events);
   }
 
-  async visitSucceededProxyCall(call: CallBase<AnyTuple>, context: VisitingContext): Promise<void> {
+  async visitSucceededProxyCall(call: CallBase<AnyTuple>, context: NodeContext): Promise<void> {
     const success = true;
     const events = context.eventQueue.all();
 
     await this.visitProxyCall(call, context, success, events);
   }
 
-  async visitProxyCall(call: CallBase<AnyTuple>, context: VisitingContext, success: boolean, events: AnyEvent[]) {
+  async visitProxyCall(call: CallBase<AnyTuple>, context: NodeContext, success: boolean, events: AnyEvent[]) {
     let [innerCall, innerOrigin] = this.callAndOriginFromProxy(call);
 
     const visitedCall: VisitedCall = {

--- a/src/impls/nodes/utility/asDerivative.ts
+++ b/src/impls/nodes/utility/asDerivative.ts
@@ -1,4 +1,4 @@
-import { AnyEvent, EventCountingContext, NestedCallNode, VisitedCall, VisitingContext } from '../../../interfaces';
+import { AnyEvent, EventCountingContext, NestedCallNode, VisitedCall, NodeContext } from '../../../interfaces';
 import { CallBase } from '@polkadot/types/types/calls';
 import { AnyTuple } from '@polkadot/types-codec/types';
 import { INumber } from '@polkadot/types-codec/types/interfaces';
@@ -19,7 +19,7 @@ export class AsDerivativeNode implements NestedCallNode {
     return endExclusive;
   }
 
-  async visit(call: CallBase<AnyTuple>, context: VisitingContext): Promise<void> {
+  async visit(call: CallBase<AnyTuple>, context: NodeContext): Promise<void> {
     if (!context.callSucceeded) {
       await this.visitFailedCall(call, context);
       context.logger.info('AsDerivative - failed or reverted by outer parent');
@@ -31,14 +31,14 @@ export class AsDerivativeNode implements NestedCallNode {
     await this.visitSucceededCall(call, context);
   }
 
-  private async visitFailedCall(call: CallBase<AnyTuple>, context: VisitingContext): Promise<void> {
+  private async visitFailedCall(call: CallBase<AnyTuple>, context: NodeContext): Promise<void> {
     const success = false;
     const events: AnyEvent[] = [];
 
     await this.visitInnerCall(call, context, success, events);
   }
 
-  private async visitSucceededCall(call: CallBase<AnyTuple>, context: VisitingContext): Promise<void> {
+  private async visitSucceededCall(call: CallBase<AnyTuple>, context: NodeContext): Promise<void> {
     const success = true;
     const events = context.eventQueue.all();
 
@@ -47,7 +47,7 @@ export class AsDerivativeNode implements NestedCallNode {
 
   private async visitInnerCall(
     call: CallBase<AnyTuple>,
-    context: VisitingContext,
+    context: NodeContext,
     success: boolean,
     events: AnyEvent[],
   ): Promise<void> {

--- a/src/impls/nodes/utility/batch.ts
+++ b/src/impls/nodes/utility/batch.ts
@@ -1,4 +1,4 @@
-import { AnyEvent, EventCountingContext, NestedCallNode, VisitingContext } from '../../../interfaces';
+import { AnyEvent, EventCountingContext, NestedCallNode, NodeContext } from '../../../interfaces';
 import { VisitedCall } from '../../../interfaces';
 import { CallBase } from '@polkadot/types/types/calls';
 import { AnyTuple } from '@polkadot/types-codec/types';
@@ -36,7 +36,7 @@ export class BatchNode implements NestedCallNode {
     return endExclusive;
   }
 
-  async visit(call: CallBase<AnyTuple>, context: VisitingContext): Promise<void> {
+  async visit(call: CallBase<AnyTuple>, context: NodeContext): Promise<void> {
     let innerCalls = call.args[0] as IVec<CallBase<AnyTuple>>;
 
     context.logger.info(`Visiting utility.batch with ${innerCalls.length} inner calls`);
@@ -91,7 +91,7 @@ export class BatchNode implements NestedCallNode {
       if (!visitedCall) continue;
       let events = visitedCall.events.map(e => e.method);
 
-      context.logger.info(`Batch - visiting batch item at ${i}, item events: ${events}`);
+      context.logger.info(`Batch - visiting batch item at ${i}, item events: ${events.length}`);
 
       await context.nestedVisit(visitedCall);
     }

--- a/src/impls/nodes/utility/batchAll.ts
+++ b/src/impls/nodes/utility/batchAll.ts
@@ -1,4 +1,4 @@
-import { EventCountingContext, NestedCallNode, VisitingContext } from '../../../interfaces';
+import { EventCountingContext, NestedCallNode, NodeContext } from '../../../interfaces';
 import { VisitedCall } from '../../../interfaces';
 import { CallBase } from '@polkadot/types/types/calls';
 import { AnyTuple } from '@polkadot/types-codec/types';
@@ -36,7 +36,7 @@ export class BatchAllNode implements NestedCallNode {
     return endExclusive;
   }
 
-  async visit(call: CallBase<AnyTuple>, context: VisitingContext): Promise<void> {
+  async visit(call: CallBase<AnyTuple>, context: NodeContext): Promise<void> {
     let innerCalls = call.args[0] as IVec<CallBase<AnyTuple>>;
 
     context.logger.info(`Visiting utility.batchAll with ${innerCalls.length} inner calls`);
@@ -78,7 +78,7 @@ export class BatchAllNode implements NestedCallNode {
       if (!visitedCall) continue;
       let events = visitedCall.events.map(e => e.method);
 
-      context.logger.info(`BatchAll - visiting batch item at ${i}, item events: ${events}`);
+      context.logger.info(`BatchAll - visiting batch item at ${i}, item events: ${events.length}`);
 
       await context.nestedVisit(visitedCall);
     }

--- a/src/impls/nodes/utility/forceBatch.ts
+++ b/src/impls/nodes/utility/forceBatch.ts
@@ -1,4 +1,4 @@
-import { EventCountingContext, NestedCallNode, VisitingContext } from '../../../interfaces';
+import { EventCountingContext, NestedCallNode, NodeContext } from '../../../interfaces';
 import { VisitedCall } from '../../../interfaces';
 import { CallBase } from '@polkadot/types/types/calls';
 import { AnyTuple } from '@polkadot/types-codec/types';
@@ -6,7 +6,6 @@ import { IVec } from '@polkadot/types-codec/types/interfaces';
 import {
   BatchCompleted,
   BatchCompletedWithErrors,
-  BatchInterrupted,
   ItemCompleted,
   ItemFailed,
   takeCompletedBatchItemEvents,
@@ -48,7 +47,7 @@ export class ForceBatchNode implements NestedCallNode {
     return endExclusive;
   }
 
-  async visit(call: CallBase<AnyTuple>, context: VisitingContext): Promise<void> {
+  async visit(call: CallBase<AnyTuple>, context: NodeContext): Promise<void> {
     let innerCalls = call.args[0] as IVec<CallBase<AnyTuple>>;
 
     context.logger.info(`Visiting utility.forceBatch with ${innerCalls.length} inner calls`);
@@ -99,7 +98,7 @@ export class ForceBatchNode implements NestedCallNode {
       if (!visitedCall) continue;
       let events = visitedCall.events.map(e => e.method);
 
-      context.logger.info(`ForceBatch - visiting batch item at ${i}, item events: ${events}`);
+      context.logger.info(`ForceBatch - visiting batch item at ${i}, item events: ${events.length}`);
 
       await context.nestedVisit(visitedCall);
     }

--- a/src/impls/nodes/utility/types.ts
+++ b/src/impls/nodes/utility/types.ts
@@ -1,4 +1,4 @@
-import { VisitingContext } from '../../../interfaces';
+import { NodeContext } from '../../../interfaces';
 import { CallBase } from '@polkadot/types/types/calls';
 import { AnyTuple } from '@polkadot/types-codec/types';
 
@@ -8,7 +8,7 @@ export const BatchInterrupted = api.events.utility?.BatchInterrupted;
 export const ItemCompleted = api.events.utility?.ItemCompleted;
 export const ItemFailed = api.events.utility?.ItemFailed;
 
-export function takeCompletedBatchItemEvents(context: VisitingContext, call: CallBase<AnyTuple>) {
+export function takeCompletedBatchItemEvents(context: NodeContext, call: CallBase<AnyTuple>) {
   const internalEventsEndExclusive = context.endExclusiveToSkipInternalEvents(call);
 
   // internalEnd is exclusive => it holds index of last internal event

--- a/src/interfaces/call-visitor.ts
+++ b/src/interfaces/call-visitor.ts
@@ -7,14 +7,19 @@ export interface CallWalk {
   walk(source: SubstrateExtrinsic, visitor: CallVisitor): Promise<void>;
 }
 
-export interface CallVisitor {
-  visit(call: VisitedCall): Promise<void>;
+export interface VisitorContext {
+  stopped: boolean;
+  stop(): void;
 }
 
-export type CallHandler = (call: VisitedCall) => Promise<void>;
+export type CallHandler = (call: VisitedCall, context: VisitorContext) => void | Promise<void>;
+
+export interface CallVisitor {
+  visit: CallHandler;
+}
 
 export interface CallVisitorBuilder {
-  on(module: string, call: string, handler: CallHandler): CallVisitorBuilder;
+  on(module: string, calls: string | string[], handler: CallHandler): CallVisitorBuilder;
   ignoreFailedCalls(ignore: boolean): CallVisitorBuilder;
   build(): CallVisitor;
 }

--- a/src/interfaces/nested-call-node.ts
+++ b/src/interfaces/nested-call-node.ts
@@ -16,10 +16,10 @@ export interface NestedCallNode {
    */
   endExclusiveToSkipInternalEvents(call: CallBase<AnyTuple>, context: EventCountingContext): number;
 
-  visit(call: CallBase<AnyTuple>, context: VisitingContext): Promise<void>;
+  visit(call: CallBase<AnyTuple>, context: NodeContext): Promise<void>;
 }
 
-export interface VisitingContext {
+export interface NodeContext {
   origin: string;
 
   callSucceeded: boolean;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
+    "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noPropertyAccessFromIndexSignature": true,
     "noUncheckedIndexedAccess": true,


### PR DESCRIPTION
### Added ability to defined multiple calls in call visitor
```ts
const visitor = CreateCallVisitorBuilder()
  .on("utility", ["batch", "batchAll", "forceBatch"], handler)
  .build();
```

### Added ability to stop traversing for visitor handler. After this all nested call will be ignored.
```ts
const visitor = CreateCallVisitorBuilder()
  .on("utility", 'batch', (call, context) => {
    if (shouldBeStopped(call)) {
      context.stop();
    }
  })
  .build();
```